### PR TITLE
Create svgScaled as an image not raw svg to allow downloading

### DIFF
--- a/vector_icon.css
+++ b/vector_icon.css
@@ -8,16 +8,18 @@
   display: flex;
   align-self: center;
   text-align: center;
-  max-height: 400px;
   min-width: 200px;
-  overflow: hidden
+  overflow: hidden;
 }
 
 #preview-scaled > svg > * {
   transform: scale(4);
 }
 
-#preview-original > svg, #preview-scaled > svg {
+#preview-original > svg,
+#preview-scaled > svg,
+#preview-original > img,
+#preview-scaled > img {
   border: 1px solid rgba(0, 0, 0, 0.1);
 }
 

--- a/vector_icon.js
+++ b/vector_icon.js
@@ -227,13 +227,18 @@ function updatePreviewIfVectorIcon(source_code, delegate, container) {
   original.innerHTML = '';
   original.appendChild(svg);
 
-  var scaled = container.querySelector('#preview-scaled');
-  scaled.innerHTML = '';
-  var scaledSvg = svg.cloneNode(true);
+  var svgSource = (new XMLSerializer).serializeToString(svg);
+
+  var scaledSvg = document.createElement('img');
   scaledSvg.setAttribute('width',
       parseFloat(svg.getAttribute('width')) * SCALE);
   scaledSvg.setAttribute('height',
       parseFloat(svg.getAttribute('height')) * SCALE);
+  scaledSvg.setAttribute('src',
+     'data:image/svg+xml;utf8,'+svgSource);
+
+  var scaled = container.querySelector('#preview-scaled');
+  scaled.innerHTML = '';
   scaled.appendChild(scaledSvg);
 }
 


### PR DESCRIPTION
Raw SVG in html doesn't support right-click to download in Chrome.

Modified the code to create an img tag containing the svg as a data url that can be downloaded properly.